### PR TITLE
Add escaping on %

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,3 +3,12 @@
 A simple tool to generate Ruby [strftime](http://www.ruby-doc.org/core/Time.html#method-i-strftime) directives from a given example date.
 
 ![strftimer example](https://s3.eu-west-2.amazonaws.com/edforshaw.co.uk/images/strftimer-is-open-source/example.gif)
+
+Development
+-----------
+
+Launch on http://localhost:4567/ via:
+
+```rb
+bundle exec ruby strftimer.rb
+```

--- a/models/escape_translator.rb
+++ b/models/escape_translator.rb
@@ -1,0 +1,19 @@
+class EscapeTranslator
+  ESCAPE_REGEXP = /%/
+
+  def initialize(query)
+    @query = query
+  end
+
+  def translation
+    @_translation ||= build_translation
+  end
+
+  private
+
+  attr_reader :query
+
+  def build_translation
+    query.gsub(ESCAPE_REGEXP) { "%%" }
+  end
+end

--- a/models/translator.rb
+++ b/models/translator.rb
@@ -22,6 +22,7 @@ class Translator
 
   def build_translation
     str = query
+    str = EscapeTranslator.new(str).translation
     str = IsoTranslator.new(str).translation
     str = TimeTranslator.new(str).translation
     str = DateTranslator.new(str).translation

--- a/spec/models/translator_spec.rb
+++ b/spec/models/translator_spec.rb
@@ -148,7 +148,11 @@ describe Translator do
       ["2020-06-26T16:40:00.000UTC", "%Y-%m-%dT%H:%M:%S.%L%Z"],
       ["20200626T153930Z", "%Y%m%dT%H%M%SZ"],
       ["2020-07-14T11:11:11.123456", "%Y-%m-%dT%H:%M:%S.%6N"],
-      ["2020-07-14T11:11:11.123456789+03:00", "%Y-%m-%dT%H:%M:%S.%9N%:z"]
+      ["2020-07-14T11:11:11.123456789+03:00", "%Y-%m-%dT%H:%M:%S.%9N%:z"],
+
+      ["", ""],
+      ["some text", "some text"],
+      ["%2020%", "%%%Y%%"],
     ].each do |input, expected_output|
       it "given input \"#{input}\" it returns \"#{expected_output}\"" do
         translator = described_class.new(input)

--- a/views/index.erb
+++ b/views/index.erb
@@ -39,7 +39,7 @@
     </main>
 
     <footer>
-      <a href="https://github.com/edforshaw/strftimer.com">Github</a>
+      <a href="https://github.com/edforshaw/strftimer.com">GitHub</a>
       ·
       <a href="https://edforshaw.co.uk">edforshaw.co.uk</a>
     </footer>


### PR DESCRIPTION
Hi there! This PR should help make sure suggested strings containing `%` don’t end up as errors.